### PR TITLE
Configure more kubernetes related providers

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -10,12 +10,27 @@ data "terraform_remote_state" "kubernetes" {
 }
 
 locals {
-  kubernetes_host = "${data.terraform_remote_state.kubernetes.outputs.dns_records[0].name}.freifunk-duesseldorf.de"
+  kubernetes_host    = "${data.terraform_remote_state.kubernetes.outputs.dns_records[0].name}.freifunk-duesseldorf.de"
+  kubernetes_api_url = "https://${local.kubernetes_host}:8443"
 }
 
 provider "kubernetes" {
-  host  = "https://${local.kubernetes_host}:8443"
+  host  = local.kubernetes_api_url
   token = data.terraform_remote_state.kubernetes.outputs.k8s_api_token
+}
+
+provider "kubernetes-alpha" {
+  host  = local.kubernetes_api_url
+  token = data.terraform_remote_state.kubernetes.outputs.k8s_api_token
+
+  server_side_planning = true
+}
+
+provider "helm" {
+  kubernetes {
+    host  = local.kubernetes_api_url
+    token = data.terraform_remote_state.kubernetes.outputs.k8s_api_token
+  }
 }
 
 resource "kubernetes_namespace" "demo" {


### PR DESCRIPTION
This adds these providers:
- [`hashicorp/kubernetes-alpha`](https://registry.terraform.io/providers/hashicorp/kubernetes-alpha/latest/docs) allows creating any kind of manifest and validates via the kubernetes api
- [`hashicorp/helm`](https://registry.terraform.io/providers/hashicorp/helm/latest/docs) allows applying premade helm charts